### PR TITLE
fix: use VirtualSize instead of SizeOfRawData for Windows PE .bun section

### DIFF
--- a/vpcc/__main__.py
+++ b/vpcc/__main__.py
@@ -321,7 +321,7 @@ def _find_bun_section_pe(data) -> tuple[int, int]:
             vsize   = _struct.unpack_from("<I", data, s + 8)[0]
             rsize   = _struct.unpack_from("<I", data, s + 16)[0]
             raw_off = _struct.unpack_from("<I", data, s + 20)[0]
-            return (raw_off, rsize or vsize)
+            return (raw_off, vsize or rsize)
     raise RuntimeError(".bun section not found (PE)")
 
 


### PR DESCRIPTION
markdown

## Problem
`vpcc patch` fails on Windows PE builds with:
fail [bun-inplace] Bun trailer invalid - format change
plain


## Root Cause
On Windows PE builds, `.bun` section has:
- `VirtualSize`   = 131,532,925 bytes (actual data)
- `SizeOfRawData` = 131,533,312 bytes (+387 bytes file-alignment padding)

Current code uses `rsize or vsize`, causing `bun_hi` to land inside trailing NUL padding. Trailer validation reads `\x00` bytes instead of the real trailer and fails.

## Fix
Change section size resolution to prioritize `VirtualSize`:
```python
return (raw_off, vsize or rsize)
Verification
Tested on Claude Code 2.1.119 Windows build:
plain

95 ok · 0 failed · 0 skipped