### PR TITLE
Fix upstream regression reports and Windows PE padding

### DIFF
--- a/.github/scripts/upstream_check.py
+++ b/.github/scripts/upstream_check.py
@@ -46,20 +46,50 @@ def parse_dry_run(out: str) -> list[dict]:
     return rows
 
 
+def load_patch_types(patch_dir: Path = Path("patches")) -> dict[str, str]:
+    """Map patch id to patch type so meta-patch failures are not called regex drift."""
+    out: dict[str, str] = {}
+    for f in patch_dir.glob("*.json"):
+        try:
+            obj = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        pid = obj.get("id")
+        if isinstance(pid, str):
+            out[pid] = str(obj.get("type") or "")
+    return out
+
+
+def classify_rows(rows: list[dict], patch_types: dict[str, str] | None = None) -> dict[str, list | int]:
+    """Classify dry-run failures into JS signature breakage vs meta-patch failures."""
+    patch_types = patch_types or {}
+    broken_signatures: list[dict] = []
+    meta_failures: list[dict] = []
+    for r in rows:
+        ptype = patch_types.get(r["id"], "")
+        is_js_patch = ptype in ("", "js_replace")
+        if r["status"] == "fail":
+            (broken_signatures if is_js_patch else meta_failures).append(r)
+        elif r["status"] == "ok" and is_js_patch and "would apply 0" in r["msg"]:
+            broken_signatures.append(r)
+    return {
+        "broken_signatures": broken_signatures,
+        "meta_failures": meta_failures,
+        "needs_issue": len(broken_signatures) + len(meta_failures),
+    }
+
+
 def main() -> int:
     rc_status, out_status = sh(["vpcc", "status"])
     rc_dry, out_dry       = sh(["vpcc", "patch", "--dry-run"])
     rows                  = parse_dry_run(out_dry)
 
-    failed = [r for r in rows if r["status"] == "fail"]
     ok     = [r for r in rows if r["status"] == "ok"]
-    noop   = [r for r in rows if r["status"] == "ok" and "no-op" in r["msg"]]
-    missing_regex = [r for r in rows if r["status"] == "ok"
-                     and "would apply 0" in r["msg"]]
-
-    # A patch counts as broken when its dry-run says it failed OR when it ran
-    # fine but matched zero locations (upstream changed the signature).
-    broken = failed + missing_regex
+    patch_types = load_patch_types()
+    classified = classify_rows(rows, patch_types)
+    broken = classified["broken_signatures"]
+    meta_failed = classified["meta_failures"]
+    clean_ok = [r for r in ok if r not in broken]
 
     rc_real, out_real = sh(["vpcc", "patch"])
     rc_verify, out_verify = sh(["vpcc", "verify"])
@@ -69,17 +99,26 @@ def main() -> int:
         f"",
         f"- **Claude Code version**: `{CC_VERSION}`",
         f"- **vpcc patches total**: {len(rows)}",
-        f"- **clean applies**: {len(ok) - len(broken)}",
+        f"- **clean applies**: {len(clean_ok)}",
         f"- **broken signatures**: {len(broken)}",
-        f"",
     ]
+    if meta_failed:
+        lines.append(f"- **meta patch failures**: {len(meta_failed)}")
+    lines.append("")
     if broken:
-        lines += ["## Broken patches", ""]
+        lines += ["## Broken signature patches", ""]
         for b in broken:
             lines.append(f"- `{b['id']}` — {b['msg']}")
-        lines += ["", "### Action", "",
+        lines += ["", "### Signature action", "",
                   "Update the regex/offsets in `patches/<id>.json` for the "
                   "affected patches and push a new release.", ""]
+    if meta_failed:
+        lines += ["## Meta patch failures", ""]
+        for b in meta_failed:
+            lines.append(f"- `{b['id']}` — {b['msg']}")
+        lines += ["", "### Meta action", "",
+                  "Investigate the patch implementation or install/runtime "
+                  "environment; this is not regex signature drift.", ""]
     lines += [
         "## `vpcc status`",
         "```", out_status.strip(), "```",
@@ -91,11 +130,14 @@ def main() -> int:
     ]
     REPORT.write_text("\n".join(lines))
 
+    needs_issue = classified["needs_issue"]
     if GHOUT:
         with open(GHOUT, "a") as f:
-            f.write(f"broken={len(broken)}\n")
+            f.write(f"broken={needs_issue}\n")
+            f.write(f"broken_signatures={len(broken)}\n")
+            f.write(f"meta_failed={len(meta_failed)}\n")
             f.write(f"total={len(rows)}\n")
-    print(f"broken={len(broken)} total={len(rows)}")
+    print(f"broken={needs_issue} signatures={len(broken)} meta={len(meta_failed)} total={len(rows)}")
     return 0
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,7 @@ jobs:
         run: python -m pip install -e .
       - name: Compile sources
         run: python -m compileall vpcc .github/scripts/upstream_check.py
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v
       - name: CLI help smoke test
         run: python -m vpcc --help

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from vpcc import __main__ as vpcc_main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_upstream_check():
+    path = REPO_ROOT / ".github" / "scripts" / "upstream_check.py"
+    spec = importlib.util.spec_from_file_location("upstream_check", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["upstream_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _minimal_pe_with_bun(vsize: int, rsize: int, payload: bytes) -> bytes:
+    pe_off = 0x80
+    coff = pe_off + 4
+    opt_size = 0
+    sect_table = coff + 20 + opt_size
+    raw_off = 0x200
+    data = bytearray(raw_off + rsize)
+
+    data[:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, pe_off)
+    data[pe_off:pe_off + 4] = b"PE\x00\x00"
+    struct.pack_into("<H", data, coff + 2, 1)      # NumberOfSections
+    struct.pack_into("<H", data, coff + 16, opt_size)
+
+    s = sect_table
+    data[s:s + 8] = b".bun\x00\x00\x00\x00"
+    struct.pack_into("<I", data, s + 8, vsize)     # VirtualSize
+    struct.pack_into("<I", data, s + 16, rsize)    # SizeOfRawData
+    struct.pack_into("<I", data, s + 20, raw_off)  # PointerToRawData
+
+    data[raw_off:raw_off + len(payload)] = payload
+    return bytes(data)
+
+
+class BunPERegressionTests(unittest.TestCase):
+    def test_pe_bun_section_uses_virtual_size_not_raw_padding(self) -> None:
+        vsize = 96
+        rsize = 128
+        payload = b"A" * (vsize - len(vpcc_main._BUN_TRAILER)) + vpcc_main._BUN_TRAILER
+        data = _minimal_pe_with_bun(vsize, rsize, payload)
+
+        off, size = vpcc_main._find_bun_section_pe(bytearray(data))
+
+        self.assertEqual(off, 0x200)
+        self.assertEqual(size, vsize)
+
+    def test_bun_trailer_validation_ignores_pe_alignment_padding(self) -> None:
+        vsize = 96
+        rsize = 128
+        payload = b"A" * (vsize - len(vpcc_main._BUN_TRAILER)) + vpcc_main._BUN_TRAILER
+        data = _minimal_pe_with_bun(vsize, rsize, payload)
+        raw_off = 0x200
+
+        self.assertTrue(vpcc_main._bun_section_has_valid_trailer(data, raw_off, raw_off + rsize))
+
+
+class McpGuardRegressionTests(unittest.TestCase):
+    def test_mcp_guard_dry_run_succeeds_without_installed_preload(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            with patch.object(Path, "home", return_value=Path(home)):
+                ok, msg = vpcc_main._apply_mcp_guard({}, dry_run=True)
+
+            self.assertTrue(ok)
+            self.assertIn("would", msg)
+            self.assertFalse((Path(home) / ".local/share/void-patcher/claude-preload.js").exists())
+
+
+class WrapperRegressionTests(unittest.TestCase):
+    def test_wrapper_install_creates_parent_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = Path(tmp) / ".local" / "bin" / "claude"
+
+            ok, msg = vpcc_main._apply_wrapper({"wrapper_path": str(wrapper)}, "bun_sea", None)
+
+            self.assertTrue(ok, msg)
+            self.assertTrue(wrapper.exists())
+            self.assertTrue(os.access(wrapper, os.X_OK))
+
+
+class UpstreamCheckRegressionTests(unittest.TestCase):
+    def test_meta_failures_do_not_count_as_broken_signatures(self) -> None:
+        upstream_check = _load_upstream_check()
+        rows = [
+            {"status": "ok", "id": "js-good", "msg": "would apply 1 in-place"},
+            {"status": "ok", "id": "js-zero", "msg": "would apply 0 in-place"},
+            {"status": "fail", "id": "mcp-guard", "msg": "preload format unexpected"},
+        ]
+        patch_types = {"js-good": "js_replace", "js-zero": "js_replace", "mcp-guard": "mcp_guard"}
+
+        classified = upstream_check.classify_rows(rows, patch_types)
+
+        self.assertEqual([r["id"] for r in classified["broken_signatures"]], ["js-zero"])
+        self.assertEqual([r["id"] for r in classified["meta_failures"]], ["mcp-guard"])
+        self.assertEqual(classified["needs_issue"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vpcc/__main__.py
+++ b/vpcc/__main__.py
@@ -215,6 +215,12 @@ import struct as _struct
 _BUN_TRAILER = b"\n---- Bun! ----\n"
 
 
+def _bun_section_has_valid_trailer(data: bytes | bytearray, bun_lo: int, bun_hi: int) -> bool:
+    """Accept Bun section trailer with optional PE file-alignment NUL padding."""
+    section = bytes(data[bun_lo:bun_hi]).rstrip(b"\x00")
+    return section.endswith(_BUN_TRAILER)
+
+
 def _bun_section_is_bytecode(section_bytes: bytes) -> bool:
     """True when .bun section uses compiled Bun bytecode — must use in-place patching."""
     return b"// @bun @bytecode" in section_bytes[:1024]
@@ -321,7 +327,10 @@ def _find_bun_section_pe(data) -> tuple[int, int]:
             vsize   = _struct.unpack_from("<I", data, s + 8)[0]
             rsize   = _struct.unpack_from("<I", data, s + 16)[0]
             raw_off = _struct.unpack_from("<I", data, s + 20)[0]
-            return (raw_off, rsize or vsize)
+            # PE SizeOfRawData includes file-alignment padding. VirtualSize is
+            # the live .bun payload length; using raw size can land trailer
+            # validation inside trailing NUL padding on Windows builds.
+            return (raw_off, vsize or rsize)
     raise RuntimeError(".bun section not found (PE)")
 
 
@@ -403,7 +412,7 @@ def patch_bun_sea_inplace(binary: Path, patches: list) -> dict:
     bun_off, bun_size = _find_bun_section(data)
     bun_lo, bun_hi = bun_off, bun_off + bun_size
 
-    if bytes(data[bun_hi - len(_BUN_TRAILER):bun_hi]) != _BUN_TRAILER:
+    if not _bun_section_has_valid_trailer(data, bun_lo, bun_hi):
         return {"ok": False, "err": "Bun trailer invalid — format change", "applied": 0, "skipped": 0}
 
     # Narrow the writable region to the active entry bundle only, so we never
@@ -793,36 +802,44 @@ def _apply_mcp_guard(p: dict, dry_run: bool = False) -> tuple[bool, str]:
         '        p.on("close", () => clearTimeout(t)); } return p; }; } catch(_) {}\n'
     )
 
-    # Install preload if missing
-    if not preload_dst.exists():
-        if not preload_src.exists():
-            return False, "preload source missing — run vpcc install-preload first"
-        if not dry_run:
-            preload_dir.mkdir(parents=True, exist_ok=True)
-            preload_dst.write_bytes(preload_src.read_bytes())
-
-    # Add guard code to preload
-    if preload_dst.exists():
-        content = preload_dst.read_text(encoding="utf-8")
-        already_guarded = GUARD_MARKER in content
-    else:
-        content = ""
-        already_guarded = False
-
-    if not already_guarded:
+    def inject_guard(content: str) -> str | None:
         inject_at = "globalThis.__VPCC_PRELOAD_ACTIVE__ = true;"
         if inject_at in content:
-            if not dry_run:
-                preload_dst.write_text(
-                    content.replace(inject_at, inject_at + GUARD_CODE), encoding="utf-8"
-                )
-        else:
-            return False, "preload format unexpected"
+            return content.replace(inject_at, inject_at + GUARD_CODE, 1)
+        tail = "\n})();"
+        idx = content.rfind(tail)
+        if idx >= 0:
+            return content[:idx] + GUARD_CODE + content[idx:]
+        return None
+
+    preload_missing = not preload_dst.exists()
+    if preload_missing:
+        if not preload_src.exists():
+            return False, "preload source missing — run vpcc install-preload first"
+        content = preload_src.read_text(encoding="utf-8")
+        if not dry_run:
+            preload_dir.mkdir(parents=True, exist_ok=True)
+            preload_dst.write_text(content, encoding="utf-8")
+    else:
+        content = preload_dst.read_text(encoding="utf-8")
+
+    already_guarded = GUARD_MARKER in content
+    if already_guarded:
+        if dry_run and preload_missing:
+            return True, "would install preload (mcp-guard already present)"
+        return True, "no-op (already applied)"
+
+    new_content = inject_guard(content)
+    if new_content is None:
+        return False, "preload format unexpected"
 
     if dry_run:
-        return True, "would add mcp-guard to preload" if not already_guarded else "no-op (already applied)"
+        if preload_missing:
+            return True, "would install preload and add mcp-guard"
+        return True, "would add mcp-guard to preload"
 
-    return True, "no-op (already applied)" if already_guarded else "mcp-guard added to preload"
+    preload_dst.write_text(new_content, encoding="utf-8")
+    return True, "mcp-guard added to preload"
 
 
 def _apply_wrapper(p: dict, kind: str, target: "Path | None", dry_run: bool = False) -> tuple[bool, str]:
@@ -855,8 +872,9 @@ def _apply_wrapper(p: dict, kind: str, target: "Path | None", dry_run: bool = Fa
         if dry_run:
             return True, "would install native BUN_OPTIONS wrapper"
 
+        wrapper_path.parent.mkdir(parents=True, exist_ok=True)
         wrapper_path.unlink(missing_ok=True)
-        wrapper_path.write_text(WRAPPER_CONTENT)
+        wrapper_path.write_text(WRAPPER_CONTENT, encoding="utf-8")
         wrapper_path.chmod(0o755)
         return True, "native BUN_OPTIONS wrapper installed"
     else:
@@ -872,8 +890,9 @@ def _apply_wrapper(p: dict, kind: str, target: "Path | None", dry_run: bool = Fa
                 pass
         if dry_run:
             return True, "would install cli.js wrapper"
+        wrapper_path.parent.mkdir(parents=True, exist_ok=True)
         wrapper_path.unlink(missing_ok=True)
-        wrapper_path.write_text(content)
+        wrapper_path.write_text(content, encoding="utf-8")
         wrapper_path.chmod(0o755)
         return True, "cli.js wrapper installed"
 
@@ -1375,7 +1394,7 @@ def main() -> int:
         help="Show if remote patches differ from local")
 
     sub.add_parser("install-preload",
-        help="Deploy runtime monkey-patch preload hook (100% survival layer)")
+        help="Deploy runtime monkey-patch preload hook (100%% survival layer)")
     sub.add_parser("uninstall-preload",
         help="Remove runtime preload hook")
 


### PR DESCRIPTION
## Summary
- fix Windows PE `.bun` parsing to use `VirtualSize` instead of `SizeOfRawData` alignment padding
- accept Bun trailers followed by PE NUL padding
- make `mcp-guard` dry-runs succeed when preload is not installed yet
- separate upstream-watch JS signature breakage from meta-patch failures
- create wrapper parent directories during fresh installs
- add dependency-free regression tests and run them in CI

## Verification
- `python3 -m unittest discover -s tests -v` → 5 passed
- `python3 -m compileall vpcc .github/scripts/upstream_check.py tests` → pass
- `python3 -m vpcc patch --dry-run` against local Claude Code 2.1.120 → `95 ok · 0 failed · 0 skipped`
- temp install `@anthropic-ai/claude-code@2.1.123`; `vpcc patch --dry-run` → `95 ok · 0 failed · 0 skipped`
- temp install `@anthropic-ai/claude-code@2.1.123`; `vpcc patch` → `95 ok · 0 failed · 0 skipped`
- temp install `@anthropic-ai/claude-code@2.1.123`; `vpcc verify` → `✓ all patches verified`
- temp install `@anthropic-ai/claude-code@2.1.123`; `.github/scripts/upstream_check.py` → `broken=0 signatures=0 meta=0 total=95`
- `git diff --check` → pass

Closes #6
Closes #8
Closes #15
Closes #16
