### PR TITLE
fix(windows): probe npm.cmd / npm.exe before bare npm in _npm_global_roots

### DIFF
--- a/vpcc/__main__.py
+++ b/vpcc/__main__.py
@@ -52,12 +52,23 @@ _BUN_SECTION = ".bun"
 
 def _npm_global_roots() -> list[Path]:
     roots: list[Path] = []
-    try:
-        r = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True, timeout=5)
-        if r.returncode == 0 and r.stdout.strip():
-            roots.insert(0, Path(r.stdout.strip()))
-    except Exception:
-        pass
+    # On Windows the npm shim is npm.cmd (or npm.exe), not bare npm; Python's
+    # subprocess.run does not honor PATHEXT, so a bare ["npm", ...] invocation
+    # raises FileNotFoundError before the bin resolution ever finds the shim.
+    # Probe candidates in order; first success wins.
+    npm_candidates = ["npm"]
+    if os.name == "nt":
+        npm_candidates = ["npm.cmd", "npm.exe", "npm"]
+    for npm in npm_candidates:
+        try:
+            r = subprocess.run([npm, "root", "-g"], capture_output=True, text=True, timeout=5)
+            if r.returncode == 0 and r.stdout.strip():
+                roots.insert(0, Path(r.stdout.strip()))
+                break
+        except (FileNotFoundError, OSError):
+            continue
+        except Exception:
+            break
     home = Path.home()
     roots += [
         home / ".npm-global/lib/node_modules",


### PR DESCRIPTION
## Problem

On Windows, `npm` is a `.cmd` shim, not a binary. Python's `subprocess.run` does not honor `PATHEXT`, so `subprocess.run(["npm", "root", "-g"])` raises `FileNotFoundError` before bin resolution finds the shim. The current code catches the exception silently and falls through to the home-directory fallback list, which on a default Windows install contains no real candidates.

The result: `find_target()` either returns nothing or picks up a stale `@anthropic-ai/native-installer` from an old install layout instead of the actual binary the user launches via `claude.cmd`. The user reports a "no target" or "wrong binary" outcome with no useful diagnostic.

This was originally reported in #22, which closed when the `%APPDATA%\npm` fallback landed at line 110-114. That fallback works as a safety net, but only kicks in if the npm probe yields nothing. The npm probe itself still fails on Windows in the documented way, so a clean install where `npm root -g` is the source of truth still ends up on the fallback path silently.

## Fix

Probe `npm.cmd`, `npm.exe`, then bare `npm` in order on Windows. First success wins. Linux/macOS unchanged (single bare-`npm` probe).

```diff
-    try:
-        r = subprocess.run(["npm", "root", "-g"], capture_output=True, text=True, timeout=5)
-        if r.returncode == 0 and r.stdout.strip():
-            roots.insert(0, Path(r.stdout.strip()))
-    except Exception:
-        pass
+    npm_candidates = ["npm"]
+    if os.name == "nt":
+        npm_candidates = ["npm.cmd", "npm.exe", "npm"]
+    for npm in npm_candidates:
+        try:
+            r = subprocess.run([npm, "root", "-g"], capture_output=True, text=True, timeout=5)
+            if r.returncode == 0 and r.stdout.strip():
+                roots.insert(0, Path(r.stdout.strip()))
+                break
+        except (FileNotFoundError, OSError):
+            continue
+        except Exception:
+            break
```

## Verification

Tested locally against npm 11.x on Windows 11 (PowerShell 7.6, Git Bash 2.x, CC 2.1.154):

```
=== _npm_global_roots ===
  ✓ C:\Users\andre\AppData\Roaming\npm\node_modules
  ✗ C:\Users\andre\.npm-global\lib\node_modules
  ✗ C:\Users\andre\.local\lib\node_modules
  ✗ \usr\local\lib\node_modules
  ✗ \usr\lib\node_modules

=== find_target ===
  picked: C:\Users\andre\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\node_modules\@anthropic-ai\claude-code-win32-x64\claude.exe
  kind:   bun_sea
  exists: True
  size:   236,073,120 bytes
```

Without this PR, the first call returns an empty list and find_target lands on the `%APPDATA%\npm` fallback at line 110-114 (which works, but only by accident — the primary npm source of truth never gets consulted).

## Out of scope

- The plugin-hook MODULE_NOT_FOUND bug (#18) — separate PR with the on-disk PowerShell rewriter + preload Section 7.
- The `%APPDATA%\npm` fallback at line 110-114 stays as-is; it remains useful when `npm` itself is not on PATH.

## Refs

- #22 (closed): original report. The APPDATA fallback landed; the npm.cmd probe did not.
- `OUR_CHANGES.md` § "Python code" — local description of this exact fix.