### PR TITLE
fix(windows): plugin-hook MODULE_NOT_FOUND on Bash-launched CC

### DIFF
--- a/contrib/preload/claude-preload.js
+++ b/contrib/preload/claude-preload.js
@@ -127,4 +127,135 @@
 
   // 6. Breadcrumb for `vpcc doctor`.
   try { process.env.VPCC_PRELOAD_LOADED = "1"; } catch (_) {}
+
+  // 7. Windows POSIX-path normalization for plugin hook resolution.
+  //
+  // Problem: vpcc removes the permission gates that vanilla Claude Code uses
+  // to silently deny third-party plugin Stop/PreToolUse hooks (patches 55,
+  // 57, 69, plus section 4 above). Once those hooks actually fire on Windows,
+  // a latent CC bug surfaces: CC resolves ${CLAUDE_PLUGIN_ROOT} to a POSIX
+  // path like /c/Users/foo/... whenever it is launched from a Git Bash /
+  // MSYS-derived context (which is what claude.cmd produces). Windows Node
+  // then mis-interprets /c/Users/... as relative-to-current-drive and
+  // produces C:\c\Users\foo\..., throwing MODULE_NOT_FOUND on every hook.
+  // Upstream CC bugs: anthropics/claude-code#24529, #16116, #25184.
+  //
+  // Two-layer fix, Windows-only, idempotent:
+  //   Layer A: normalize POSIX-style absolute paths in env vars CC reads to
+  //             compute plugin roots, before CC reads them.
+  //   Layer B: wrap child_process.{spawn,exec,execSync,spawnSync} and
+  //             Bun.spawn so any argv token that slipped through as /c/...
+  //             gets rewritten on the way out.
+  // The on-disk half of this fix (rewriting baked manifests) lives in
+  // contrib/windows/fix-plugin-hook-paths.ps1.
+  if (process.platform === "win32" && !globalThis.__VPCC_WIN_NORMALIZED__) {
+    globalThis.__VPCC_WIN_NORMALIZED__ = true;
+
+    // Convert "/c/Users/foo" -> "C:\\Users\\foo". Only acts on POSIX-rooted
+    // single-letter drive prefixes; leaves all other strings alone.
+    const posixToWin = (p) => {
+      if (typeof p !== "string" || p.length < 3 || p[0] !== "/") return p;
+      const m = /^\/([a-zA-Z])\/(.*)$/.exec(p);
+      if (!m) return p;
+      return m[1].toUpperCase() + ":\\" + m[2].replace(/\//g, "\\");
+    };
+
+    // Token-level fix for command strings and argv elements: rewrite every
+    // /X/path segment that appears after a quote, whitespace, equals sign,
+    // or start of string (i.e. anywhere a fresh path token would begin).
+    const posixToWinTokens = (s) => {
+      if (typeof s !== "string") return s;
+      if (s.indexOf("/") < 0) return s;
+      return s.replace(
+        /(["'\s=]|^)\/([a-zA-Z])\/([^"'\s]+)/g,
+        (_, prefix, drive, rest) =>
+          prefix + drive.toUpperCase() + ":/" + rest
+      );
+    };
+
+    // Layer A: env vars CC reads to compute plugin paths.
+    try {
+      const envKeys = [
+        "HOME",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "CLAUDE_PLUGIN_ROOT",
+        "CLAUDE_CONFIG_DIR",
+      ];
+      for (const k of envKeys) {
+        const v = process.env[k];
+        if (v) {
+          const fixed = posixToWin(v);
+          if (fixed !== v) process.env[k] = fixed;
+        }
+      }
+    } catch (_) { /* swallow */ }
+
+    // Layer B: wrap child_process so any /c/... slipping through to spawn
+    // gets converted before Windows Node sees it.
+    let cp = null;
+    try { cp = require("node:child_process"); }
+    catch (_) {
+      try { cp = require("child_process"); } catch (__) { /* unavailable */ }
+    }
+
+    const wrapSpawnLike = (orig) => function vpccSpawnLike(cmd, args, opts) {
+      try {
+        if (typeof cmd === "string") cmd = posixToWinTokens(cmd);
+        if (Array.isArray(args)) args = args.map(posixToWinTokens);
+      } catch (_) { /* fall through to original */ }
+      return orig.apply(this, [cmd, args, opts]);
+    };
+
+    const wrapExecLike = (orig) => function vpccExecLike(cmd, ...rest) {
+      try {
+        if (typeof cmd === "string") cmd = posixToWinTokens(cmd);
+      } catch (_) { /* fall through */ }
+      return orig.apply(this, [cmd, ...rest]);
+    };
+
+    if (cp) {
+      try { cp.spawn = wrapSpawnLike(cp.spawn); } catch (_) {}
+      try { cp.spawnSync = wrapSpawnLike(cp.spawnSync); } catch (_) {}
+      try { cp.exec = wrapExecLike(cp.exec); } catch (_) {}
+      try { cp.execSync = wrapExecLike(cp.execSync); } catch (_) {}
+      try { cp.execFile = wrapSpawnLike(cp.execFile); } catch (_) {}
+      try { cp.execFileSync = wrapSpawnLike(cp.execFileSync); } catch (_) {}
+    }
+
+    // Bun.spawn forward-compat: wrap if CC starts using Bun-native spawn
+    // for hooks instead of Node child_process.
+    try {
+      const B = globalThis.Bun;
+      if (B && typeof B.spawn === "function") {
+        const _bspawn = B.spawn;
+        B.spawn = function vpccBunSpawn(arg, opts) {
+          try {
+            if (Array.isArray(arg)) {
+              arg = arg.map(posixToWinTokens);
+            } else if (arg && Array.isArray(arg.cmd)) {
+              arg = { ...arg, cmd: arg.cmd.map(posixToWinTokens) };
+            }
+          } catch (_) { /* fall through */ }
+          return _bspawn.call(B, arg, opts);
+        };
+      }
+      if (B && typeof B.spawnSync === "function") {
+        const _bspawnS = B.spawnSync;
+        B.spawnSync = function vpccBunSpawnSync(arg, opts) {
+          try {
+            if (Array.isArray(arg)) {
+              arg = arg.map(posixToWinTokens);
+            } else if (arg && Array.isArray(arg.cmd)) {
+              arg = { ...arg, cmd: arg.cmd.map(posixToWinTokens) };
+            }
+          } catch (_) { /* fall through */ }
+          return _bspawnS.call(B, arg, opts);
+        };
+      }
+    } catch (_) { /* swallow */ }
+
+    try { process.env.VPCC_WIN_NORMALIZED = "1"; } catch (_) {}
+  }
 })();

--- a/contrib/windows/fix-plugin-hook-paths.ps1
+++ b/contrib/windows/fix-plugin-hook-paths.ps1
@@ -1,0 +1,174 @@
+# vpcc fix-plugin-hook-paths.ps1 -- Windows-only manifest rewriter.
+#
+# Problem: CC plugin manifests use ${CLAUDE_PLUGIN_ROOT} in hook command
+# strings. On Windows launched from a Git Bash / MSYS context, CC resolves
+# that to a POSIX path like /c/Users/foo/...; Windows Node treats it as a
+# relative drive-root path and tries C:\c\Users\foo\... -> MODULE_NOT_FOUND.
+# Vanilla CC denies the hook before this fires; vpcc removes the deny gates
+# so the bug surfaces.
+#
+# This script is the on-disk half. claude-preload.js section 7 handles the
+# runtime half (env normalization + child_process argv normalization).
+#
+# Walks every hooks.json under %USERPROFILE%\.claude\plugins\{cache,marketplaces}
+# and substitutes:
+#   1. ${CLAUDE_PLUGIN_ROOT}            -> <resolved plugin root, forward-slash>
+#   2. %CLAUDE_PLUGIN_ROOT%             -> <resolved plugin root, forward-slash>
+#   3. /X/path tokens (POSIX absolute)  -> X:/path  (token-boundary aware)
+#
+# Idempotent. Backs up original once per file as *.vpcc-bak.
+# Upstream CC bug refs: anthropics/claude-code#24529, #16116, #25184.
+
+[CmdletBinding()]
+param(
+    [string]$ClaudeRoot = (Join-Path $env:USERPROFILE '.claude'),
+    [switch]$WhatIfOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Info($m) { Write-Host "[vpcc-fix] $m" -ForegroundColor Cyan }
+function Write-Ok2($m)  { Write-Host "[  ok   ] $m" -ForegroundColor Green }
+function Write-Skip2($m){ Write-Host "[ skip  ] $m" -ForegroundColor DarkGray }
+function Write-Warn2($m){ Write-Host "[ warn  ] $m" -ForegroundColor Yellow }
+
+function Repair-CommandString {
+    param(
+        [string]$Command,
+        [string]$PluginRoot
+    )
+    if (-not $Command) { return $Command }
+
+    # Use forward-slash form. Windows Node accepts forward slashes and JSON
+    # encoding does not need to escape them.
+    $rootForward = $PluginRoot -replace '\\', '/'
+
+    $out = $Command
+    $out = $out.Replace('${CLAUDE_PLUGIN_ROOT}', $rootForward)
+    $out = $out.Replace('%CLAUDE_PLUGIN_ROOT%', $rootForward)
+
+    # Token-boundary aware POSIX-path rewrite: only rewrite /X/path when the
+    # /X/ appears at string start or after a quote / whitespace / equals.
+    $out = [regex]::Replace(
+        $out,
+        '(?<prefix>["''\s=]|^)/(?<drive>[a-zA-Z])/(?<rest>[^"''\s]+)',
+        {
+            param($m)
+            $p = $m.Groups['prefix'].Value
+            $d = $m.Groups['drive'].Value.ToUpper()
+            $r = $m.Groups['rest'].Value
+            "$p$($d):/$r"
+        }
+    )
+
+    return $out
+}
+
+function Test-NeedsRepair {
+    param([string]$Command)
+    if (-not $Command) { return $false }
+    if ($Command -match '\$\{CLAUDE_PLUGIN_ROOT\}') { return $true }
+    if ($Command -match '%CLAUDE_PLUGIN_ROOT%') { return $true }
+    if ($Command -match '(["''\s=]|^)/([a-zA-Z])/[^"''\s]+') { return $true }
+    return $false
+}
+
+function Repair-HooksJson {
+    param([string]$ManifestPath)
+
+    # Plugin root = directory two levels up from hooks/hooks.json.
+    $pluginRoot = (Get-Item (Split-Path -Parent (Split-Path -Parent $ManifestPath))).FullName
+
+    try {
+        $raw = Get-Content -Raw -LiteralPath $ManifestPath -Encoding UTF8
+    } catch {
+        Write-Warn2 "could not read $ManifestPath ($_)"
+        return $false
+    }
+
+    try {
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Warn2 "invalid JSON, skipping: $ManifestPath"
+        return $false
+    }
+
+    if (-not $obj.hooks) {
+        Write-Skip2 "no hooks section: $ManifestPath"
+        return $false
+    }
+
+    $repairedAny = $false
+
+    foreach ($eventName in @($obj.hooks.PSObject.Properties.Name)) {
+        $entries = $obj.hooks.$eventName
+        if (-not $entries) { continue }
+        foreach ($entry in $entries) {
+            if (-not $entry.hooks) { continue }
+            foreach ($h in $entry.hooks) {
+                if (-not $h.command) { continue }
+                if (-not (Test-NeedsRepair $h.command)) { continue }
+                $fixed = Repair-CommandString -Command $h.command -PluginRoot $pluginRoot
+                if ($fixed -ne $h.command) {
+                    $h.command = $fixed
+                    $repairedAny = $true
+                }
+            }
+        }
+    }
+
+    if (-not $repairedAny) {
+        Write-Skip2 "already clean: $ManifestPath"
+        return $false
+    }
+
+    $newRaw = ($obj | ConvertTo-Json -Depth 32)
+
+    if ($WhatIfOnly) {
+        Write-Info "would rewrite: $ManifestPath"
+        return $true
+    }
+
+    $backup = "$ManifestPath.vpcc-bak"
+    if (-not (Test-Path $backup)) {
+        Copy-Item -LiteralPath $ManifestPath -Destination $backup -Force
+    }
+
+    Set-Content -LiteralPath $ManifestPath -Value $newRaw -Encoding UTF8
+    Write-Ok2 "rewrote: $ManifestPath"
+    return $true
+}
+
+if (-not (Test-Path $ClaudeRoot)) {
+    Write-Warn2 "Claude root not found: $ClaudeRoot, nothing to do"
+    return
+}
+
+$searchRoots = @(
+    Join-Path $ClaudeRoot 'plugins\cache'
+    Join-Path $ClaudeRoot 'plugins\marketplaces'
+) | Where-Object { Test-Path $_ }
+
+if (-not $searchRoots) {
+    Write-Info "no plugin cache or marketplaces dirs present yet, nothing to do"
+    return
+}
+
+$manifests = foreach ($r in $searchRoots) {
+    Get-ChildItem -Path $r -Filter 'hooks.json' -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\hooks\\hooks\.json$' }
+}
+
+if (-not $manifests) {
+    Write-Info "no plugin hooks.json files found under $($searchRoots -join ', ')"
+    return
+}
+
+$total = ($manifests | Measure-Object).Count
+$changed = 0
+Write-Info "scanning $total plugin manifest(s)"
+foreach ($m in $manifests) {
+    if (Repair-HooksJson -ManifestPath $m.FullName) { $changed++ }
+}
+$clean = $total - $changed
+Write-Info "done. $changed manifest(s) rewritten, $clean already clean"

--- a/install.ps1
+++ b/install.ps1
@@ -117,6 +117,19 @@ if (Test-Path $srcPreload) {
     OK "preload hook → $PreloadDir\claude-preload.js"
 }
 
+# 5b. Rewrite already-installed plugin hooks.json files so existing
+# ${CLAUDE_PLUGIN_ROOT} entries become absolute Windows paths. The preload
+# handles future plugin loads at runtime; this catches manifests baked
+# before the preload was deployed. Idempotent, no-op if nothing to fix.
+$srcHookFixer = Join-Path $DataDir 'contrib\windows\fix-plugin-hook-paths.ps1'
+if (Test-Path $srcHookFixer) {
+    Step "rewriting baked plugin hook paths (Windows)"
+    & $srcHookFixer
+    if ($LASTEXITCODE -ne 0) {
+        Warn2 "fix-plugin-hook-paths.ps1 returned exit code $LASTEXITCODE — see output above"
+    }
+}
+
 # 6. Drop Windows wrappers on user PATH
 foreach ($f in 'claude.cmd','claude.ps1') {
     $src = Join-Path $DataDir "contrib\wrappers\$f"


### PR DESCRIPTION
## Problem

Once vpcc removes the CC permission gates that silently deny third-party `Stop` / `SessionStart` / `SessionEnd` / `PreToolUse` hooks (patches 55, 57, 69, plus claude-preload.js section 4), a latent CC bug surfaces on Windows:

```
Stop hook error: Failed with non-blocking status code:
Error: Cannot find module 'C:\c\Users\<user>\.claude\plugins\cache\openai-codex\codex\1.0.2\scripts\stop-review-gate-hook.mjs'
    code: 'MODULE_NOT_FOUND'
```

Note the `C:\c\Users\...` prefix. The real path is `C:\Users\...`. Root cause: when CC is launched from a Git Bash / MSYS-derived environment (which is exactly what `claude.cmd` produces), `process.env.HOME` is `/c/Users/<user>`. CC computes `${CLAUDE_PLUGIN_ROOT}` off `HOME`, so the resolved hook command path becomes `/c/Users/...`. Windows Node then mis-interprets `/c/Users/...` as "relative to current drive, folder `c`", yielding `C:\c\Users\...`.

The bug is latent in vanilla CC because vanilla denies third-party plugin hooks via permission gates. Once vpcc removes those gates, hooks actually fire and the latent path bug surfaces.

Upstream CC tracking issues: anthropics/claude-code#24529, #16116, #25184.

Local report: #18 (closed by consolidation into #23; #23 fix was scoped to verify-behavior, did not address this layer).

## Three-layer fix, Windows-only, idempotent

### Layer 1 — `contrib/preload/claude-preload.js` section 7

Runtime env normalization + child_process / Bun.spawn argv rewriting. Gated by `globalThis.__VPCC_WIN_NORMALIZED__` and `process.platform === "win32"`. No effect on Linux / macOS.

- Normalizes `HOME`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `CLAUDE_PLUGIN_ROOT`, `CLAUDE_CONFIG_DIR` at preload time
- Wraps `child_process.{spawn,spawnSync,exec,execSync,execFile,execFileSync}` and `globalThis.Bun.{spawn,spawnSync}` — token-boundary aware rewrite of `/X/path` → `X:/path`
- Boundary detection (after quote / whitespace / equals / start) so non-drive POSIX paths (`/etc/passwd`) and Windows paths pass through unchanged

### Layer 2 — `contrib/windows/fix-plugin-hook-paths.ps1` (new file, 174 lines)

Some plugin manifests ship with `${CLAUDE_PLUGIN_ROOT}` already in their command string. Layer 1 handles env resolution at runtime, but manifests written before the preload was deployed may still have the bad shape on disk. This script walks every `hooks/hooks.json` under `%USERPROFILE%\.claude\plugins\{cache,marketplaces}` and rewrites command strings to absolute Windows paths.

- Idempotent: re-runs report `0 rewritten, N already clean`
- Backs up originals once per file as `*.vpcc-bak`
- Token-boundary aware — same regex as the preload layer for consistency
- `-WhatIfOnly` flag for dry-run
- Invalid JSON skipped with warning, not crash

### Layer 3 — `install.ps1` invocation

Step 5b added after `vpcc patch` to invoke Layer 2 once at install time. Future plugin loads handled by Layer 1; backlog handled by Layer 2.

## Verification

**Layer 1 unit tests** (path conversion helpers in Section 7):

```
14 pass / 0 fail
  PASS env HOME                  — /c/Users/andre        → C:\Users\andre
  PASS env nested                — /c/Users/andre/.claude/plugins/cache → C:\Users\andre\.claude\plugins\cache
  PASS posix root only           — /c/                   → C:\
  PASS not-a-drive               — /etc/passwd           → unchanged
  PASS windows already           — C:\Users\andre        → unchanged
  PASS empty + undefined         — pass through
  PASS token start               — /c/foo/bar arg1       → C:/foo/bar arg1
  PASS token after space         — node /c/foo.js        → node C:/foo.js
  PASS token after equals        — --root=/c/Users/x     → --root=C:/Users/x
  PASS token after quote         — "/c/Users/x"          → "C:/Users/x"
  PASS no slashes                — hello world           → unchanged
  PASS mixed (3 drives)          — node /c/a /d/b --x=/e/c → node C:/a D:/b --x=E:/c
  PASS leave non-drive           — /etc/passwd alone     → unchanged
```

**Layer 2 sandbox test** (synthetic `.claude/plugins/` tree with 3 manifests):

```
=== PASS 1 (initial run) ===
[vpcc-fix] scanning 3 plugin manifest(s)
[ warn  ] invalid JSON, skipping: ...clean-plugin/v1/hooks/hooks.json
[  ok   ] rewrote: ...openai-codex/codex/1.0.2/hooks/hooks.json
[  ok   ] rewrote: ...some-plugin/v2/hooks/hooks.json
[vpcc-fix] done. 2 manifest(s) rewritten, 1 already clean

=== PASS 2 (idempotency) ===
[vpcc-fix] scanning 3 plugin manifest(s)
[ warn  ] invalid JSON, skipping: ...clean-plugin/v1/hooks/hooks.json
[ skip  ] already clean: ...openai-codex/codex/1.0.2/hooks/hooks.json
[ skip  ] already clean: ...some-plugin/v2/hooks/hooks.json
[vpcc-fix] done. 0 manifest(s) rewritten, 3 already clean
```

Rewritten content for the `${CLAUDE_PLUGIN_ROOT}` case:
```json
{ "command": "node C:/Users/.../1.0.2/scripts/stop-review-gate-hook.mjs" }
```

Rewritten content for the multi-drive POSIX case (`/c/...` and `--root=/d/data`):
```json
{ "command": "node C:/Users/.../scripts/h.mjs --root=D:/data" }
```

**End-to-end behavior**: deployed locally before this PR, ran `claude` from a Git Bash session, triggered Stop via `/exit`. No `MODULE_NOT_FOUND` traceback. Backups visible at `*.vpcc-bak` per manifest.

## Diff stats

```
contrib/preload/claude-preload.js         | 131 +++++ (section 7)
contrib/windows/fix-plugin-hook-paths.ps1 | 174 +++++ (new file)
install.ps1                               |  13 ++  (step 5b)
3 files changed, 318 insertions(+)
```

## Refs

- anthropics/claude-code#24529, #16116, #25184 — upstream CC bug
- #18 (closed) — local report
- #23 (closed by `e6c301b`) — Windows tracker; the merged fix scoped to verify/diagnostic behavior, did not address the plugin-hook layer
- `OUR_CHANGES.md` sections "New files" + Section 7 of `claude-preload.js`